### PR TITLE
Image can be configured to left, right or full

### DIFF
--- a/build-config.js
+++ b/build-config.js
@@ -69,7 +69,12 @@ module.exports = {
 		},
 
 		image: {
-			toolbar: [ 'imageStyle:full', 'imageStyle:side', '|', 'imageTextAlternative' ]
+			styles: [
+				'full',
+				'alignLeft',
+				'alignRight'
+			],
+			toolbar: [ 'imageStyle:alignLeft', 'imageStyle:full', 'imageStyle:alignRight', '|', 'imageTextAlternative' ]
 		},
 
 		// UI language. Language codes follow the https://en.wikipedia.org/wiki/ISO_639-1 format.

--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -82,9 +82,15 @@ DecoupledEditor.build = {
 			]
 		},
 		image: {
+			styles: [
+				'full',
+				'alignLeft',
+				'alignRight'
+			],
 			toolbar: [
+				'imageStyle:alignLeft',
 				'imageStyle:full',
-				'imageStyle:side',
+				'imageStyle:alignRight',
 				'|',
 				'imageTextAlternative'
 			]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Image style can be configured to left, right or full. Closes #10.
