### PR TITLE
Made the error initialization catch statements more informative

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ And use it in your website:
 
 			window.editor = editor;
 		} )
-		.catch( err => {
-			console.error( err.stack );
+		.catch( error => {
+			console.error( 'There was a problem with initializing the editor', error );
 		} );
 </script>
 ```
@@ -67,9 +67,9 @@ DecoupledEditor
 
 			window.editor = editor;
 		} )
-	.catch( err => {
-		console.error( err.stack );
-	} );
+		.catch( error => {
+			console.error( 'There was a problem with initializing the editor', error );
+		} );
 ```
 
 **Note:** If you are planning to integrate CKEditor 5 deep into your application, it is actually more convenient and recommended to install and import the source modules directly (like it happens in `ckeditor.js`). Read more in the [Advanced setup guide](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/advanced-setup.html).

--- a/README.md
+++ b/README.md
@@ -61,15 +61,15 @@ import DecoupledEditor from '@ckeditor/ckeditor5-build-decoupled-document';
 
 DecoupledEditor
 	.create( document.querySelector( '#editor' ) )
-		.then( editor => {
-			// The toolbar needs to be explicitly appended.
-			document.querySelector( '#toolbar-container' ).appendChild( editor.ui.view.toolbar.element );
+	.then( editor => {
+		// The toolbar needs to be explicitly appended.
+		document.querySelector( '#toolbar-container' ).appendChild( editor.ui.view.toolbar.element );
 
-			window.editor = editor;
-		} )
-		.catch( error => {
-			console.error( 'There was a problem initializing the editor.', error );
-		} );
+		window.editor = editor;
+	} )
+	.catch( error => {
+		console.error( 'There was a problem initializing the editor.', error );
+	} );
 ```
 
 **Note:** If you are planning to integrate CKEditor 5 deep into your application, it is actually more convenient and recommended to install and import the source modules directly (like it happens in `ckeditor.js`). Read more in the [Advanced setup guide](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/advanced-setup.html).

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ And use it in your website:
 			window.editor = editor;
 		} )
 		.catch( error => {
-			console.error( 'There was a problem with initializing the editor', error );
+			console.error( 'There was a problem initializing the editor.', error );
 		} );
 </script>
 ```
@@ -68,7 +68,7 @@ DecoupledEditor
 			window.editor = editor;
 		} )
 		.catch( error => {
-			console.error( 'There was a problem with initializing the editor', error );
+			console.error( 'There was a problem initializing the editor.', error );
 		} );
 ```
 

--- a/sample/index.html
+++ b/sample/index.html
@@ -65,7 +65,7 @@
 			document.querySelector( '.editable-container' ).appendChild( editor.ui.view.editable.element );
 		} )
 		.catch( error => {
-			console.error( 'There was a problem with initializing the editor', error );
+			console.error( 'There was a problem initializing the editor.', error );
 		} );
 </script>
 

--- a/sample/index.html
+++ b/sample/index.html
@@ -58,15 +58,15 @@
 		<p>You can use this sample to validate whether your <a href="https://ckeditor.com/docs/ckeditor5/latest/builds/guides/development/custom-builds.html">custom build</a> works fine.</p>`;
 
 	DecoupledEditor.create( editorData )
-	.then( editor => {
-		window.editor = editor;
+		.then( editor => {
+			window.editor = editor;
 
-		document.querySelector( '.toolbar-container' ).appendChild( editor.ui.view.toolbar.element );
-		document.querySelector( '.editable-container' ).appendChild( editor.ui.view.editable.element );
-	} )
-	.catch( error => {
-		console.error( 'There was a problem with initializing the editor', error );
-	} );
+			document.querySelector( '.toolbar-container' ).appendChild( editor.ui.view.toolbar.element );
+			document.querySelector( '.editable-container' ).appendChild( editor.ui.view.editable.element );
+		} )
+		.catch( error => {
+			console.error( 'There was a problem with initializing the editor', error );
+		} );
 </script>
 
 </body>

--- a/sample/index.html
+++ b/sample/index.html
@@ -64,8 +64,8 @@
 		document.querySelector( '.toolbar-container' ).appendChild( editor.ui.view.toolbar.element );
 		document.querySelector( '.editable-container' ).appendChild( editor.ui.view.editable.element );
 	} )
-	.catch( err => {
-		console.error( err.stack );
+	.catch( error => {
+		console.error( 'There was a problem with initializing the editor', error );
 	} );
 </script>
 

--- a/tests/manual/ckeditor-cjs-version.js
+++ b/tests/manual/ckeditor-cjs-version.js
@@ -14,6 +14,6 @@ DecoupledEditor.create( document.querySelector( '#editor' ) )
 
 		window.editor = editor;
 	} )
-	.catch( err => {
-		console.error( err.stack );
+	.catch( error => {
+		console.error( 'There was a problem with initializing the editor', error );
 	} );

--- a/tests/manual/ckeditor-cjs-version.js
+++ b/tests/manual/ckeditor-cjs-version.js
@@ -15,5 +15,5 @@ DecoupledEditor.create( document.querySelector( '#editor' ) )
 		window.editor = editor;
 	} )
 	.catch( error => {
-		console.error( 'There was a problem with initializing the editor', error );
+		console.error( 'There was a problem initializing the editor.', error );
 	} );

--- a/tests/manual/ckeditor.js
+++ b/tests/manual/ckeditor.js
@@ -14,5 +14,5 @@ DecoupledEditor.create( document.querySelector( '#editor' ) )
 		window.editor = editor;
 	} )
 	.catch( error => {
-		console.error( 'There was a problem with initializing the editor', error );
+		console.error( 'There was a problem initializing the editor.', error );
 	} );

--- a/tests/manual/ckeditor.js
+++ b/tests/manual/ckeditor.js
@@ -13,6 +13,6 @@ DecoupledEditor.create( document.querySelector( '#editor' ) )
 
 		window.editor = editor;
 	} )
-	.catch( err => {
-		console.error( err.stack );
+	.catch( error => {
+		console.error( 'There was a problem with initializing the editor', error );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Example error handling in build samples is now more informative. See ckeditor/ckeditor5#1803.

---

### Additional information

There are 5 PRs in total, for each of the following packages:

* ckeditor5-build-balloon
* ckeditor5-build-balloon-block
* ckeditor5-build-classic
* ckeditor5-build-decoupled-document
* ckeditor5-build-inline